### PR TITLE
Replace deprecated header include

### DIFF
--- a/scryptjane.c
+++ b/scryptjane.c
@@ -27,7 +27,7 @@
 #define scrypt_maxp 25  /* (1 << 25) = ~33 million */
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 static void
 scrypt_fatal_error_default(const char *msg) {


### PR DESCRIPTION
Include stdlib.h instead of the non-standard malloc.h
