### PR TITLE
reduce sph_*.* size

### DIFF
--- a/src/sha3/hamsi.c
+++ b/src/sha3/hamsi.c
@@ -114,11 +114,13 @@ extern "C"{
 
 #include "hamsi_helper.c"
 
+#ifdef USE_SPH_HAMSI224
 static const sph_u32 IV224[] = {
     SPH_C32(0xc3967a67), SPH_C32(0xc3bc6c20), SPH_C32(0x4bc3bcc3),
     SPH_C32(0xa7c3bc6b), SPH_C32(0x2c204b61), SPH_C32(0x74686f6c),
     SPH_C32(0x69656b65), SPH_C32(0x20556e69)
 };
+#endif
 
 /*
  * This version is the one used in the Hamsi submission package for
@@ -132,12 +134,15 @@ static const sph_u32 IV224[] = {
 };
  */
 
+#ifdef USE_SPH_HAMSI256
 static const sph_u32 IV256[] = {
     SPH_C32(0x76657273), SPH_C32(0x69746569), SPH_C32(0x74204c65),
     SPH_C32(0x7576656e), SPH_C32(0x2c204465), SPH_C32(0x70617274),
     SPH_C32(0x656d656e), SPH_C32(0x7420456c)
 };
+#endif
 
+#ifdef USE_SPH_HAMSI384
 static const sph_u32 IV384[] = {
     SPH_C32(0x656b7472), SPH_C32(0x6f746563), SPH_C32(0x686e6965),
     SPH_C32(0x6b2c2043), SPH_C32(0x6f6d7075), SPH_C32(0x74657220),
@@ -146,6 +151,7 @@ static const sph_u32 IV384[] = {
     SPH_C32(0x43727970), SPH_C32(0x746f6772), SPH_C32(0x61706879),
     SPH_C32(0x2c204b61)
 };
+#endif
 
 static const sph_u32 IV512[] = {
     SPH_C32(0x73746565), SPH_C32(0x6c706172), SPH_C32(0x6b204172),
@@ -316,6 +322,7 @@ static const sph_u32 alpha_f[] = {
         c0 = (sc->h[0] ^= s0); \
     } while (0)
 
+#if defined(USE_SPH_HAMSI224) || defined(USE_SPH_HAMSI256) || defined(USE_SPH_HAMSI384)
 static void
 hamsi_small(sph_hamsi_small_context *sc, const unsigned char *buf, size_t num)
 {
@@ -424,6 +431,7 @@ hamsi_small_close(sph_hamsi_small_context *sc,
     for (u = 0; u < out_size_w32; u ++)
         sph_enc32be(out + (u << 2), sc->h[u]);
 }
+#endif
 
 #define DECL_STATE_BIG \
     sph_u32 c0, c1, c2, c3, c4, c5, c6, c7; \
@@ -742,6 +750,7 @@ hamsi_big_close(sph_hamsi_big_context *sc,
     }
 }
 
+#ifdef USE_SPH_HAMSI224
 /* see sph_hamsi.h */
 void
 sph_hamsi224_init(void *cc)
@@ -771,7 +780,9 @@ sph_hamsi224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
     hamsi_small_close(cc, ub, n, dst, 7);
     hamsi_small_init(cc, IV224);
 }
+#endif
 
+#ifdef USE_SPH_HAMSI256
 /* see sph_hamsi.h */
 void
 sph_hamsi256_init(void *cc)
@@ -801,7 +812,9 @@ sph_hamsi256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
     hamsi_small_close(cc, ub, n, dst, 8);
     hamsi_small_init(cc, IV256);
 }
+#endif
 
+#ifdef USE_SPH_HAMSI384
 /* see sph_hamsi.h */
 void
 sph_hamsi384_init(void *cc)
@@ -831,6 +844,7 @@ sph_hamsi384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
     hamsi_big_close(cc, ub, n, dst, 12);
     hamsi_big_init(cc, IV384);
 }
+#endif
 
 /* see sph_hamsi.h */
 void

--- a/src/sha3/sph_blake.c
+++ b/src/sha3/sph_blake.c
@@ -999,6 +999,7 @@ blake64_close(sph_blake_big_context *sc,
 
 #endif
 
+#ifdef USE_SPH_BLAKE224
 /* see sph_blake.h */
 void
 sph_blake224_init(void *cc)
@@ -1027,6 +1028,7 @@ sph_blake224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	blake32_close(cc, ub, n, dst, 7);
 	sph_blake224_init(cc);
 }
+#endif
 
 /* see sph_blake.h */
 void

--- a/src/sha3/sph_bmw.c
+++ b/src/sha3/sph_bmw.c
@@ -840,6 +840,7 @@ bmw64_close(sph_bmw_big_context *sc, unsigned ub, unsigned n,
 
 #endif
 
+#ifdef USE_SPH_BMW224
 /* see sph_bmw.h */
 void
 sph_bmw224_init(void *cc)
@@ -868,6 +869,7 @@ sph_bmw224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	bmw32_close(cc, ub, n, dst, 7);
 	sph_bmw224_init(cc);
 }
+#endif
 
 /* see sph_bmw.h */
 void
@@ -900,6 +902,7 @@ sph_bmw256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 
 #if SPH_64
 
+#ifdef USE_SPH_BMW384
 /* see sph_bmw.h */
 void
 sph_bmw384_init(void *cc)
@@ -928,6 +931,7 @@ sph_bmw384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	bmw64_close(cc, ub, n, dst, 6);
 	sph_bmw384_init(cc);
 }
+#endif
 
 /* see sph_bmw.h */
 void

--- a/src/sha3/sph_cubehash.c
+++ b/src/sha3/sph_cubehash.c
@@ -603,6 +603,7 @@ cubehash_close(sph_cubehash_context *sc, unsigned ub, unsigned n,
 		sph_enc32le(out + (z << 2), sc->state[z]);
 }
 
+#ifdef USE_SPH_CUBEHASH224
 /* see sph_cubehash.h */
 void
 sph_cubehash224_init(void *cc)
@@ -631,6 +632,7 @@ sph_cubehash224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	cubehash_close(cc, ub, n, dst, 7);
 	sph_cubehash224_init(cc);
 }
+#endif
 
 /* see sph_cubehash.h */
 void
@@ -661,6 +663,7 @@ sph_cubehash256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	sph_cubehash256_init(cc);
 }
 
+#ifdef USE_SPH_CUBEHASH384
 /* see sph_cubehash.h */
 void
 sph_cubehash384_init(void *cc)
@@ -689,6 +692,7 @@ sph_cubehash384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	cubehash_close(cc, ub, n, dst, 12);
 	sph_cubehash384_init(cc);
 }
+#endif
 
 /* see sph_cubehash.h */
 void

--- a/src/sha3/sph_echo.c
+++ b/src/sha3/sph_echo.c
@@ -643,6 +643,7 @@ mix_column(sph_u32 W[16][4], int ia, int ib, int ic, int id)
 		} \
 	} while (0)
 
+#if defined(USE_SPH_ECHO224) || defined(USE_SPH_ECHO256)
 static void
 echo_small_init(sph_echo_small_context *sc, unsigned out_len)
 {
@@ -668,6 +669,7 @@ echo_small_init(sph_echo_small_context *sc, unsigned out_len)
 	sc->ptr = 0;
 	sc->C0 = sc->C1 = sc->C2 = sc->C3 = 0;
 }
+#endif
 
 static void
 echo_big_init(sph_echo_big_context *sc, unsigned out_len)
@@ -711,6 +713,7 @@ echo_big_init(sph_echo_big_context *sc, unsigned out_len)
 	sc->C0 = sc->C1 = sc->C2 = sc->C3 = 0;
 }
 
+#if defined(USE_SPH_ECHO224) || defined(USE_SPH_ECHO256)
 static void
 echo_small_compress(sph_echo_small_context *sc)
 {
@@ -718,6 +721,7 @@ echo_small_compress(sph_echo_small_context *sc)
 
 	COMPRESS_SMALL(sc);
 }
+#endif
 
 static void
 echo_big_compress(sph_echo_big_context *sc)
@@ -727,6 +731,7 @@ echo_big_compress(sph_echo_big_context *sc)
 	COMPRESS_BIG(sc);
 }
 
+#if defined(USE_SPH_ECHO224) || defined(USE_SPH_ECHO256)
 static void
 echo_small_core(sph_echo_small_context *sc,
 	const unsigned char *data, size_t len)
@@ -761,6 +766,7 @@ echo_small_core(sph_echo_small_context *sc,
 	}
 	sc->ptr = ptr;
 }
+#endif
 
 static void
 echo_big_core(sph_echo_big_context *sc,
@@ -797,6 +803,7 @@ echo_big_core(sph_echo_big_context *sc,
 	sc->ptr = ptr;
 }
 
+#if defined(USE_SPH_ECHO224) || defined(USE_SPH_ECHO256)
 static void
 echo_small_close(sph_echo_small_context *sc, unsigned ub, unsigned n,
 	void *dst, unsigned out_size_w32)
@@ -855,6 +862,7 @@ echo_small_close(sph_echo_small_context *sc, unsigned ub, unsigned n,
 	memcpy(dst, u.tmp, out_size_w32 << 2);
 	echo_small_init(sc, out_size_w32 << 5);
 }
+#endif
 
 static void
 echo_big_close(sph_echo_big_context *sc, unsigned ub, unsigned n,
@@ -915,6 +923,7 @@ echo_big_close(sph_echo_big_context *sc, unsigned ub, unsigned n,
 	echo_big_init(sc, out_size_w32 << 5);
 }
 
+#ifdef USE_SPH_ECHO224
 /* see sph_echo.h */
 void
 sph_echo224_init(void *cc)
@@ -942,7 +951,9 @@ sph_echo224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	echo_small_close(cc, ub, n, dst, 7);
 }
+#endif
 
+#ifdef USE_SPH_ECHO256
 /* see sph_echo.h */
 void
 sph_echo256_init(void *cc)
@@ -970,7 +981,9 @@ sph_echo256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	echo_small_close(cc, ub, n, dst, 8);
 }
+#endif
 
+#ifdef USE_SPH_ECHO384
 /* see sph_echo.h */
 void
 sph_echo384_init(void *cc)
@@ -998,6 +1011,7 @@ sph_echo384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	echo_big_close(cc, ub, n, dst, 12);
 }
+#endif
 
 /* see sph_echo.h */
 void

--- a/src/sha3/sph_fugue.c
+++ b/src/sha3/sph_fugue.c
@@ -800,6 +800,7 @@ fugue2_core(sph_fugue_context *sc, const void *data, size_t len)
 	WRITE_STATE_SMALL(sc);
 }
 
+#ifdef USE_SPH_FUGUE384
 static void
 fugue3_core(sph_fugue_context *sc, const void *data, size_t len)
 {
@@ -859,6 +860,7 @@ fugue3_core(sph_fugue_context *sc, const void *data, size_t len)
 	CORE_EXIT
 	WRITE_STATE_BIG(sc);
 }
+#endif
 
 static void
 fugue4_core(sph_fugue_context *sc, const void *data, size_t len)
@@ -1000,6 +1002,7 @@ fugue2_close(sph_fugue_context *sc, unsigned ub, unsigned n,
 	}
 }
 
+#ifdef USE_SPH_FUGUE384
 static void
 fugue3_close(sph_fugue_context *sc, unsigned ub, unsigned n, void *dst)
 {
@@ -1046,6 +1049,7 @@ fugue3_close(sph_fugue_context *sc, unsigned ub, unsigned n, void *dst)
 	sph_enc32be(out + 44, S[27]);
 	sph_fugue384_init(sc);
 }
+#endif
 
 static void
 fugue4_close(sph_fugue_context *sc, unsigned ub, unsigned n, void *dst)
@@ -1114,6 +1118,7 @@ sph_fugue224_init(void *cc)
 	fugue_init(cc, 23, IV224, 7);
 }
 
+#ifdef USE_SPH_FUGUE224
 void
 sph_fugue224(void *cc, const void *data, size_t len)
 {
@@ -1131,6 +1136,7 @@ sph_fugue224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	fugue2_close(cc, ub, n, dst, 7);
 }
+#endif
 
 void
 sph_fugue256_init(void *cc)
@@ -1156,6 +1162,7 @@ sph_fugue256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	fugue2_close(cc, ub, n, dst, 8);
 }
 
+#ifdef USE_SPH_FUGUE384
 void
 sph_fugue384_init(void *cc)
 {
@@ -1179,6 +1186,7 @@ sph_fugue384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	fugue3_close(cc, ub, n, dst);
 }
+#endif
 
 void
 sph_fugue512_init(void *cc)

--- a/src/sha3/sph_groestl.c
+++ b/src/sha3/sph_groestl.c
@@ -3002,6 +3002,7 @@ groestl_big_close(sph_groestl_big_context *sc,
 	groestl_big_init(sc, (unsigned)out_len << 3);
 }
 
+#ifdef USE_SPH_GROESTL224
 /* see sph_groestl.h */
 void
 sph_groestl224_init(void *cc)
@@ -3029,6 +3030,7 @@ sph_groestl224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	groestl_small_close(cc, ub, n, dst, 28);
 }
+#endif
 
 /* see sph_groestl.h */
 void
@@ -3058,6 +3060,7 @@ sph_groestl256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	groestl_small_close(cc, ub, n, dst, 32);
 }
 
+#ifdef USE_SPH_GROESTL384
 /* see sph_groestl.h */
 void
 sph_groestl384_init(void *cc)
@@ -3085,6 +3088,7 @@ sph_groestl384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	groestl_big_close(cc, ub, n, dst, 48);
 }
+#endif
 
 /* see sph_groestl.h */
 void

--- a/src/sha3/sph_jh.c
+++ b/src/sha3/sph_jh.c
@@ -999,6 +999,7 @@ jh_close(sph_jh_context *sc, unsigned ub, unsigned n,
 	jh_init(sc, iv);
 }
 
+#ifdef USE_SPH_JH224
 /* see sph_jh.h */
 void
 sph_jh224_init(void *cc)
@@ -1026,6 +1027,7 @@ sph_jh224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	jh_close(cc, ub, n, dst, 7, IV224);
 }
+#endif
 
 /* see sph_jh.h */
 void
@@ -1055,6 +1057,7 @@ sph_jh256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	jh_close(cc, ub, n, dst, 8, IV256);
 }
 
+#ifdef USE_SPH_JH384
 /* see sph_jh.h */
 void
 sph_jh384_init(void *cc)
@@ -1082,6 +1085,7 @@ sph_jh384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	jh_close(cc, ub, n, dst, 12, IV384);
 }
+#endif
 
 /* see sph_jh.h */
 void

--- a/src/sha3/sph_keccak.c
+++ b/src/sha3/sph_keccak.c
@@ -1701,11 +1701,16 @@ keccak_core(sph_keccak_context *kc, const void *data, size_t len, size_t lim)
 
 #endif
 
+#ifdef USE_SPH_KECCAK224
 DEFCLOSE(28, 144)
+#endif
 DEFCLOSE(32, 136)
+#ifdef USE_SPH_KECCAK384
 DEFCLOSE(48, 104)
+#endif
 DEFCLOSE(64, 72)
 
+#ifdef USE_SPH_KECCAK224
 /* see sph_keccak.h */
 void
 sph_keccak224_init(void *cc)
@@ -1733,6 +1738,7 @@ sph_keccak224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	keccak_close28(cc, ub, n, dst);
 }
+#endif
 
 /* see sph_keccak.h */
 void
@@ -1762,6 +1768,7 @@ sph_keccak256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	keccak_close32(cc, ub, n, dst);
 }
 
+#ifdef USE_SPH_KECCAK384
 /* see sph_keccak.h */
 void
 sph_keccak384_init(void *cc)
@@ -1789,6 +1796,7 @@ sph_keccak384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	keccak_close48(cc, ub, n, dst);
 }
+#endif
 
 /* see sph_keccak.h */
 void

--- a/src/sha3/sph_luffa.c
+++ b/src/sha3/sph_luffa.c
@@ -1055,6 +1055,7 @@ static const sph_u32 RC44[8] = {
 
 #endif
 
+#if defined(USE_SPH_LUFFA224) || defined(USE_SPH_LUFFA256)
 static void
 luffa3(sph_luffa224_context *sc, const void *data, size_t len)
 {
@@ -1124,7 +1125,9 @@ luffa3_close(sph_luffa224_context *sc, unsigned ub, unsigned n,
 	if (out_size_w32 > 7)
 		sph_enc32be(out + 28, V07 ^ V17 ^ V27);
 }
+#endif
 
+#ifdef USE_SPH_LUFFA384
 static void
 luffa4(sph_luffa384_context *sc, const void *data, size_t len)
 {
@@ -1204,6 +1207,7 @@ luffa4_close(sph_luffa384_context *sc, unsigned ub, unsigned n, void *dst)
 		}
 	}
 }
+#endif
 
 static void
 luffa5(sph_luffa512_context *sc, const void *data, size_t len)
@@ -1289,6 +1293,7 @@ luffa5_close(sph_luffa512_context *sc, unsigned ub, unsigned n, void *dst)
 	}
 }
 
+#ifdef USE_SPH_LUFFA224
 /* see sph_luffa.h */
 void
 sph_luffa224_init(void *cc)
@@ -1321,7 +1326,9 @@ sph_luffa224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	luffa3_close(cc, ub, n, dst, 7);
 	sph_luffa224_init(cc);
 }
+#endif
 
+#ifdef USE_SPH_LUFFA256
 /* see sph_luffa.h */
 void
 sph_luffa256_init(void *cc)
@@ -1354,7 +1361,9 @@ sph_luffa256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	luffa3_close(cc, ub, n, dst, 8);
 	sph_luffa256_init(cc);
 }
+#endif
 
+#ifdef USE_SPH_LUFFA384
 /* see sph_luffa.h */
 void
 sph_luffa384_init(void *cc)
@@ -1387,6 +1396,7 @@ sph_luffa384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	luffa4_close(cc, ub, n, dst);
 	sph_luffa384_init(cc);
 }
+#endif
 
 /* see sph_luffa.h */
 void

--- a/src/sha3/sph_ripemd.c
+++ b/src/sha3/sph_ripemd.c
@@ -290,6 +290,7 @@ sph_ripemd_comp(const sph_u32 msg[16], sph_u32 val[4])
  * RIPEMD-128.
  */
 
+#ifdef USE_SPH_RIPEMD128
 /*
  * Round constants for RIPEMD-128.
  */
@@ -538,6 +539,7 @@ sph_ripemd128_comp(const sph_u32 msg[16], sph_u32 val[4])
 	RIPEMD128_ROUND_BODY(RIPEMD128_IN, val);
 #undef RIPEMD128_IN
 }
+#endif
 
 /* ===================================================================== */
 /*

--- a/src/sha3/sph_sha2.c
+++ b/src/sha3/sph_sha2.c
@@ -49,17 +49,6 @@
 #define SSG2_0(x)      (ROTR(x, 7) ^ ROTR(x, 18) ^ SPH_T32((x) >> 3))
 #define SSG2_1(x)      (ROTR(x, 17) ^ ROTR(x, 19) ^ SPH_T32((x) >> 10))
 
-static const sph_u32 H224[8] = {
-	SPH_C32(0xC1059ED8), SPH_C32(0x367CD507), SPH_C32(0x3070DD17),
-	SPH_C32(0xF70E5939), SPH_C32(0xFFC00B31), SPH_C32(0x68581511),
-	SPH_C32(0x64F98FA7), SPH_C32(0xBEFA4FA4)
-};
-
-static const sph_u32 H256[8] = {
-	SPH_C32(0x6A09E667), SPH_C32(0xBB67AE85), SPH_C32(0x3C6EF372),
-	SPH_C32(0xA54FF53A), SPH_C32(0x510E527F), SPH_C32(0x9B05688C),
-	SPH_C32(0x1F83D9AB), SPH_C32(0x5BE0CD19)
-};
 
 /*
  * The SHA2_ROUND_BODY defines the body for a SHA-224 / SHA-256
@@ -613,6 +602,7 @@ sha2_round(const unsigned char *data, sph_u32 r[8])
 #undef SHA2_IN
 }
 
+#ifdef USE_SPH_SHA224
 /* see sph_sha2.h */
 void
 sph_sha224_init(void *cc)
@@ -620,13 +610,21 @@ sph_sha224_init(void *cc)
 	sph_sha224_context *sc;
 
 	sc = cc;
-	memcpy(sc->val, H224, sizeof H224);
+	sc->val[0] = SPH_C32(0xC1059ED8);
+	sc->val[1] = SPH_C32(0x367CD507);
+	sc->val[2] = SPH_C32(0x3070DD17);
+	sc->val[3] = SPH_C32(0xF70E5939);
+	sc->val[4] = SPH_C32(0xFFC00B31);
+	sc->val[5] = SPH_C32(0x68581511);
+	sc->val[6] = SPH_C32(0x64F98FA7);
+	sc->val[7] = SPH_C32(0xBEFA4FA4);
 #if SPH_64
 	sc->count = 0;
 #else
 	sc->count_high = sc->count_low = 0;
 #endif
 }
+#endif
 
 /* see sph_sha2.h */
 void
@@ -635,7 +633,14 @@ sph_sha256_init(void *cc)
 	sph_sha256_context *sc;
 
 	sc = cc;
-	memcpy(sc->val, H256, sizeof H256);
+	sc->val[0] = SPH_C32(0x6A09E667);
+	sc->val[1] = SPH_C32(0xBB67AE85);
+	sc->val[2] = SPH_C32(0x3C6EF372);
+	sc->val[3] = SPH_C32(0xA54FF53A);
+	sc->val[4] = SPH_C32(0x510E527F);
+	sc->val[5] = SPH_C32(0x9B05688C);
+	sc->val[6] = SPH_C32(0x1F83D9AB);
+	sc->val[7] = SPH_C32(0x5BE0CD19);
 #if SPH_64
 	sc->count = 0;
 #else
@@ -648,6 +653,7 @@ sph_sha256_init(void *cc)
 #define BE32   1
 #include "md_helper.c"
 
+#ifdef USE_SPH_SHA224
 /* see sph_sha2.h */
 void
 sph_sha224_close(void *cc, void *dst)
@@ -663,6 +669,7 @@ sph_sha224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	sha224_addbits_and_close(cc, ub, n, dst, 7);
 	sph_sha224_init(cc);
 }
+#endif
 
 /* see sph_sha2.h */
 void
@@ -680,6 +687,7 @@ sph_sha256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	sph_sha256_init(cc);
 }
 
+#ifdef USE_SPH_SHA224
 /* see sph_sha2.h */
 void
 sph_sha224_comp(const sph_u32 msg[16], sph_u32 val[8])
@@ -688,3 +696,4 @@ sph_sha224_comp(const sph_u32 msg[16], sph_u32 val[8])
 	SHA2_ROUND_BODY(SHA2_IN, val);
 #undef SHA2_IN
 }
+#endif

--- a/src/sha3/sph_sha2big.c
+++ b/src/sha3/sph_sha2big.c
@@ -90,20 +90,6 @@ static const sph_u64 K512[80] = {
 	SPH_C64(0x5FCB6FAB3AD6FAEC), SPH_C64(0x6C44198C4A475817)
 };
 
-static const sph_u64 H384[8] = {
-	SPH_C64(0xCBBB9D5DC1059ED8), SPH_C64(0x629A292A367CD507),
-	SPH_C64(0x9159015A3070DD17), SPH_C64(0x152FECD8F70E5939),
-	SPH_C64(0x67332667FFC00B31), SPH_C64(0x8EB44A8768581511),
-	SPH_C64(0xDB0C2E0D64F98FA7), SPH_C64(0x47B5481DBEFA4FA4)
-};
-
-static const sph_u64 H512[8] = {
-	SPH_C64(0x6A09E667F3BCC908), SPH_C64(0xBB67AE8584CAA73B),
-	SPH_C64(0x3C6EF372FE94F82B), SPH_C64(0xA54FF53A5F1D36F1),
-	SPH_C64(0x510E527FADE682D1), SPH_C64(0x9B05688C2B3E6C1F),
-	SPH_C64(0x1F83D9ABFB41BD6B), SPH_C64(0x5BE0CD19137E2179)
-};
-
 /*
  * This macro defines the body for a SHA-384 / SHA-512 compression function
  * implementation. The "in" parameter should evaluate, when applied to a
@@ -176,6 +162,7 @@ sha3_round(const unsigned char *data, sph_u64 r[8])
 #undef SHA3_IN
 }
 
+#ifdef USE_SPH_SHA384
 /* see sph_sha3.h */
 void
 sph_sha384_init(void *cc)
@@ -183,9 +170,17 @@ sph_sha384_init(void *cc)
 	sph_sha384_context *sc;
 
 	sc = cc;
-	memcpy(sc->val, H384, sizeof H384);
+	sc->val[0] = SPH_C64(0xCBBB9D5DC1059ED8);
+	sc->val[1] = SPH_C64(0x629A292A367CD507);
+	sc->val[2] = SPH_C64(0x9159015A3070DD17);
+	sc->val[3] = SPH_C64(0x152FECD8F70E5939);
+	sc->val[4] = SPH_C64(0x67332667FFC00B31);
+	sc->val[5] = SPH_C64(0x8EB44A8768581511);
+	sc->val[6] = SPH_C64(0xDB0C2E0D64F98FA7);
+	sc->val[7] = SPH_C64(0x47B5481DBEFA4FA4);
 	sc->count = 0;
 }
+#endif
 
 /* see sph_sha3.h */
 void
@@ -194,7 +189,14 @@ sph_sha512_init(void *cc)
 	sph_sha512_context *sc;
 
 	sc = cc;
-	memcpy(sc->val, H512, sizeof H512);
+	sc->val[0] = SPH_C64(0x6A09E667F3BCC908);
+	sc->val[1] = SPH_C64(0xBB67AE8584CAA73B);
+	sc->val[2] = SPH_C64(0x3C6EF372FE94F82B);
+	sc->val[3] = SPH_C64(0xA54FF53A5F1D36F1);
+	sc->val[4] = SPH_C64(0x510E527FADE682D1);
+	sc->val[5] = SPH_C64(0x9B05688C2B3E6C1F);
+	sc->val[6] = SPH_C64(0x1F83D9ABFB41BD6B);
+	sc->val[7] = SPH_C64(0x5BE0CD19137E2179);
 	sc->count = 0;
 }
 
@@ -203,6 +205,7 @@ sph_sha512_init(void *cc)
 #define BE64   1
 #include "md_helper.c"
 
+#ifdef USE_SPH_SHA384
 /* see sph_sha3.h */
 void
 sph_sha384_close(void *cc, void *dst)
@@ -218,6 +221,7 @@ sph_sha384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	sha384_addbits_and_close(cc, ub, n, dst, 6);
 	sph_sha384_init(cc);
 }
+#endif
 
 /* see sph_sha3.h */
 void
@@ -235,6 +239,7 @@ sph_sha512_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	sph_sha512_init(cc);
 }
 
+#ifdef USE_SPH_SHA384
 /* see sph_sha3.h */
 void
 sph_sha384_comp(const sph_u64 msg[16], sph_u64 val[8])
@@ -243,5 +248,6 @@ sph_sha384_comp(const sph_u64 msg[16], sph_u64 val[8])
 	SHA3_ROUND_BODY(SHA3_IN, val);
 #undef SHA3_IN
 }
+#endif
 
 #endif

--- a/src/sha3/sph_shabal.c
+++ b/src/sha3/sph_shabal.c
@@ -662,6 +662,7 @@ shabal_close(void *cc, unsigned ub, unsigned n, void *dst, unsigned size_words)
 	shabal_init(sc, size_words << 5);
 }
 
+#ifdef USE_SPH_SHABAL192
 /* see sph_shabal.h */
 void
 sph_shabal192_init(void *cc)
@@ -689,7 +690,9 @@ sph_shabal192_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shabal_close(cc, ub, n, dst, 6);
 }
+#endif
 
+#ifdef USE_SPH_SHABAL224
 /* see sph_shabal.h */
 void
 sph_shabal224_init(void *cc)
@@ -717,6 +720,7 @@ sph_shabal224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shabal_close(cc, ub, n, dst, 7);
 }
+#endif
 
 /* see sph_shabal.h */
 void
@@ -746,6 +750,7 @@ sph_shabal256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	shabal_close(cc, ub, n, dst, 8);
 }
 
+#ifdef USE_SPH_SHABAL384
 /* see sph_shabal.h */
 void
 sph_shabal384_init(void *cc)
@@ -773,6 +778,7 @@ sph_shabal384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 {
 	shabal_close(cc, ub, n, dst, 12);
 }
+#endif
 
 /* see sph_shabal.h */
 void

--- a/src/sha3/sph_shavite.c
+++ b/src/sha3/sph_shavite.c
@@ -148,6 +148,8 @@ static const sph_u32 IV512[] = {
 		(k3) = kt; \
 	} while (0)
 
+#if defined(USE_SPH_SHAVITE224) || defined(USE_SPH_SHAVITE256)
+
 #if SPH_SMALL_FOOTPRINT_SHAVITE
 
 /*
@@ -718,6 +720,7 @@ c256(sph_shavite_small_context *sc, const void *msg)
 	sc->h[0x7] ^= p7;
 }
 
+#endif
 #endif
 
 #if SPH_SMALL_FOOTPRINT_SHAVITE
@@ -1475,6 +1478,7 @@ c512(sph_shavite_big_context *sc, const void *msg)
 
 #endif
 
+#if defined(USE_SPH_SHAVITE224) || defined(USE_SPH_SHAVITE256)
 static void
 shavite_small_init(sph_shavite_small_context *sc, const sph_u32 *iv)
 {
@@ -1549,6 +1553,7 @@ shavite_small_close(sph_shavite_small_context *sc,
 	for (u = 0; u < out_size_w32; u ++)
 		sph_enc32le((unsigned char *)dst + (u << 2), sc->h[u]);
 }
+#endif
 
 static void
 shavite_big_init(sph_shavite_big_context *sc, const sph_u32 *iv)
@@ -1639,6 +1644,7 @@ shavite_big_close(sph_shavite_big_context *sc,
 		sph_enc32le((unsigned char *)dst + (u << 2), sc->h[u]);
 }
 
+#ifdef USE_SPH_SHAVITE224
 /* see sph_shavite.h */
 void
 sph_shavite224_init(void *cc)
@@ -1668,7 +1674,9 @@ sph_shavite224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	shavite_small_close(cc, ub, n, dst, 7);
 	shavite_small_init(cc, IV224);
 }
+#endif
 
+#ifdef USE_SPH_SHAVITE256
 /* see sph_shavite.h */
 void
 sph_shavite256_init(void *cc)
@@ -1698,7 +1706,9 @@ sph_shavite256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	shavite_small_close(cc, ub, n, dst, 8);
 	shavite_small_init(cc, IV256);
 }
+#endif
 
+#ifdef USE_SPH_SHAVITE384
 /* see sph_shavite.h */
 void
 sph_shavite384_init(void *cc)
@@ -1728,6 +1738,7 @@ sph_shavite384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	shavite_big_close(cc, ub, n, dst, 12);
 	shavite_big_init(cc, IV384);
 }
+#endif
 
 /* see sph_shavite.h */
 void

--- a/src/sha3/sph_simd.c
+++ b/src/sha3/sph_simd.c
@@ -992,6 +992,7 @@ compress_small(sph_simd_small_context *sc, int last)
 #define D3   (sc->state[15])
 #endif
 
+#if defined(USE_SPH_SIMD224) || defined(USE_SPH_SIMD256) || defined(USE_SPH_SIMD384)
 static void
 compress_small(sph_simd_small_context *sc, int last)
 {
@@ -1071,6 +1072,7 @@ compress_small(sph_simd_small_context *sc, int last)
 	WRITE_STATE_SMALL(sc);
 #endif
 }
+#endif
 
 #if SPH_SIMD_NOCOPY
 #undef A0
@@ -1557,6 +1559,7 @@ static const u32 IV512[] = {
 	C32(0x8FA14956), C32(0x21BF9BD3), C32(0xB94D0943), C32(0x6FFDDC22)
 };
 
+#if defined(USE_SPH_SIMD224) || defined(USE_SPH_SIMD256) || defined(USE_SPH_SIMD384)
 static void
 init_small(void *cc, const u32 *iv)
 {
@@ -1567,6 +1570,7 @@ init_small(void *cc, const u32 *iv)
 	sc->count_low = sc->count_high = 0;
 	sc->ptr = 0;
 }
+#endif
 
 static void
 init_big(void *cc, const u32 *iv)
@@ -1579,6 +1583,7 @@ init_big(void *cc, const u32 *iv)
 	sc->ptr = 0;
 }
 
+#if defined(USE_SPH_SIMD224) || defined(USE_SPH_SIMD256) || defined(USE_SPH_SIMD384)
 static void
 update_small(void *cc, const void *data, size_t len)
 {
@@ -1603,6 +1608,7 @@ update_small(void *cc, const void *data, size_t len)
 		}
 	}
 }
+#endif
 
 static void
 update_big(void *cc, const void *data, size_t len)
@@ -1629,6 +1635,7 @@ update_big(void *cc, const void *data, size_t len)
 	}
 }
 
+#if defined(USE_SPH_SIMD224) || defined(USE_SPH_SIMD256) || defined(USE_SPH_SIMD384)
 static void
 encode_count_small(unsigned char *dst,
 	u32 low, u32 high, size_t ptr, unsigned n)
@@ -1639,6 +1646,7 @@ encode_count_small(unsigned char *dst,
 	sph_enc32le(dst, low);
 	sph_enc32le(dst + 4, high);
 }
+#endif
 
 static void
 encode_count_big(unsigned char *dst,
@@ -1651,6 +1659,7 @@ encode_count_big(unsigned char *dst,
 	sph_enc32le(dst + 4, high);
 }
 
+#if defined(USE_SPH_SIMD224) || defined(USE_SPH_SIMD256) || defined(USE_SPH_SIMD384)
 static void
 finalize_small(void *cc, unsigned ub, unsigned n, void *dst, size_t dst_len)
 {
@@ -1672,6 +1681,7 @@ finalize_small(void *cc, unsigned ub, unsigned n, void *dst, size_t dst_len)
 	for (d = dst, u = 0; u < dst_len; u ++)
 		sph_enc32le(d + (u << 2), sc->state[u]);
 }
+#endif
 
 static void
 finalize_big(void *cc, unsigned ub, unsigned n, void *dst, size_t dst_len)
@@ -1695,6 +1705,7 @@ finalize_big(void *cc, unsigned ub, unsigned n, void *dst, size_t dst_len)
 		sph_enc32le(d + (u << 2), sc->state[u]);
 }
 
+#ifdef USE_SPH_SIMD224
 void
 sph_simd224_init(void *cc)
 {
@@ -1719,7 +1730,9 @@ sph_simd224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	finalize_small(cc, ub, n, dst, 7);
 	sph_simd224_init(cc);
 }
+#endif
 
+#ifdef USE_SPH_SIMD256
 void
 sph_simd256_init(void *cc)
 {
@@ -1744,7 +1757,9 @@ sph_simd256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	finalize_small(cc, ub, n, dst, 8);
 	sph_simd256_init(cc);
 }
+#endif
 
+#ifdef USE_SPH_SIMD384
 void
 sph_simd384_init(void *cc)
 {
@@ -1769,6 +1784,7 @@ sph_simd384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	finalize_big(cc, ub, n, dst, 12);
 	sph_simd384_init(cc);
 }
+#endif
 
 void
 sph_simd512_init(void *cc)

--- a/src/sha3/sph_skein.c
+++ b/src/sha3/sph_skein.c
@@ -1130,6 +1130,7 @@ sph_skein256_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 }
 #endif
 
+#ifdef USE_SPH_SKEIN224
 /* see sph_skein.h */
 void
 sph_skein224_init(void *cc)
@@ -1158,6 +1159,7 @@ sph_skein224_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	skein_big_close(cc, ub, n, dst, 28);
 	sph_skein224_init(cc);
 }
+#endif
 
 /* see sph_skein.h */
 void
@@ -1195,6 +1197,7 @@ sph_skein384_init(void *cc)
 	skein_big_init(cc, IV384);
 }
 
+#ifdef USE_SPH_SKEIN384
 /* see sph_skein.h */
 void
 sph_skein384(void *cc, const void *data, size_t len)
@@ -1216,6 +1219,7 @@ sph_skein384_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
 	skein_big_close(cc, ub, n, dst, 48);
 	sph_skein384_init(cc);
 }
+#endif
 
 /* see sph_skein.h */
 void


### PR DESCRIPTION
* reduced size of the `multihashing.node` from 1.1MB(1,111,968) to 907kB (928,120) on linux.